### PR TITLE
Fix incorrect `base_dir` property

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,6 @@
         "phpstan/phpstan": "^2",
         "szepeviktor/phpstan-wordpress": "^2.0.0-rc.2",
         "phpstan/extension-installer": "^1.2",
-        "paulthewalton/acf-stubs": "^5.8",
         "phpstan/phpstan-phpunit": "^2",
         "phpstan/phpstan-mockery": "^2.0",
         "shish/safe": "^2"

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -14,9 +14,6 @@ parameters:
 		- .
 		- tests
 
-	scanFiles:
-		- vendor/paulthewalton/acf-stubs/acf-stubs.php
-
 	excludePaths:
 		analyse:
 			- vendor

--- a/src/class-wp-requirements.php
+++ b/src/class-wp-requirements.php
@@ -2,7 +2,7 @@
 /**
  *  This file is part of mundschenk-at/check-wp-requirements.
  *
- *  Copyright 2014-2024 Peter Putzer.
+ *  Copyright 2014-2025 Peter Putzer.
  *  Copyright 2009-2011 KINGdesk, LLC.
  *
  *  This program is free software; you can redistribute it and/or
@@ -90,7 +90,7 @@ class WP_Requirements {
 		$this->plugin_name = $name;
 		$this->plugin_file = $plugin_path;
 		$this->textdomain  = $textdomain;
-		$this->base_dir    = __DIR__;
+		$this->base_dir    = \dirname( __DIR__ );
 
 		$this->install_requirements = \wp_parse_args(
 			$requirements,


### PR DESCRIPTION
Changes proposed in this pull request:
- Removes `acf-stubs` as a build dependency.
- Fixes the `base_dir` property after the move of to `src/`.